### PR TITLE
add release manager for 2.346.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,37 @@ jobs:
       - name: Test System version
         run: grep -oP 'VERSION=.* \K\w* \w*' /etc/os-release
         shell: bash
+  deploy:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    name: "Deploy Docker Image: ${{ github.ref }}"
+    needs:
+      - jenkins-runtime-pipeline
+      - jenkins-container-pipeline
+      - jenkins-static-image-pipeline
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'     
+      - name: Log in to the ghcr.io
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}    
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.3.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build Docker image
+        uses: docker/build-push-action@v2.6.1
+        with:
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}                

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:11-jdk
+USER root
+ENV JDK_11 true
+
+ENV JENKINS_UC https://updates.jenkins.io
+ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
+ADD setup.sh /setup.sh
+ADD plugins.txt /plugins.txt
+
+RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
+    && echo "jenkins: {}" >/usr/share/jenkins/ref/casc/jenkins.yaml 
+
+RUN /setup.sh /plugins.txt && rm -rf /setup.sh /plugins.txt
+ENTRYPOINT ["/app/bin/jenkinsfile-runner"]

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+JENKINS_VERSION=2.346.1
+JENKINS_PM_VERSION=2.5.0
+JENKINS_PM_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${JENKINS_PM_VERSION}/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
+JENKINS_CORE_URL=http://updates.jenkins.io/download/war/${JENKINS_VERSION}/jenkins.war
+JFR_VERSION=1.0-beta-30
+JENKINS_JFR_URL=https://github.com/jenkinsci/jenkinsfile-runner/releases/download/${JFR_VERSION}/jenkinsfile-runner-${JFR_VERSION}.zip
+
+# download Jenkins core
+mkdir -p /app
+echo "Downloading Jenkins core"
+curl -L ${JENKINS_CORE_URL} -o /app/jenkins.war
+unzip /app/jenkins.war -d /app/jenkins
+
+echo "Downloading Jenkinsfile-runner"
+curl -L ${JENKINS_JFR_URL} -o /app/jenkinsfile-runner-${JFR_VERSION}.zip
+unzip -q /app/jenkinsfile-runner-${JFR_VERSION}.zip -d /app
+rm /app/jenkinsfile-runner-${JFR_VERSION}.zip
+chmod +x /app/bin/jenkinsfile-runner
+
+# download plugin manager
+echo "Downloading plugin manager"
+wget $JENKINS_PM_URL -O /app/bin/jenkins-plugin-manager.jar
+
+# download plugins
+echo "Downloading minimum required plugins..."
+mkdir -p /usr/share/jenkins/ref/plugins
+java -jar /app/bin/jenkins-plugin-manager.jar --war /app/jenkins.war --plugin-file "$1" --plugin-download-directory=/usr/share/jenkins/ref/plugins
+
+echo "Jenkins plugins has been set up"


### PR DESCRIPTION
I add a temporary release manager for Jenkins war with version 2.346.1. Based on my experiments, it can compile faster than custom war packager. Therefore, I can do further experiments about the latest plugins such as s3 artifact manager. If we come up with more advanced idea, we can delete this release manager after that.

See the release manager experiement in [this project](https://github.com/Cr1t-GYM/Jenkinsfile-runner-image-release-test).