### PR TITLE
delete cache in runtime type and fix path in jfr-container-action

### DIFF
--- a/jenkins-plugin-installation-action/action.yml
+++ b/jenkins-plugin-installation-action/action.yml
@@ -12,13 +12,6 @@ runs:
       with:
         distribution: 'adopt'
         java-version: '8'
-    - uses: actions/cache@v3
-      id: cache-jenkins
-      name: Cache Jenkins
-      with:
-        path: ${{github.workspace}}/jenkins
-        key: ${{ runner.os }}-build
     - name: Download plugins
-      if: steps.cache-jenkins.outputs.cache-hit != 'true'
       run: ${{github.action_path}}/setup.sh ${{inputs.pluginstxt}}
       shell: bash

--- a/jfr-container-action/action.yml
+++ b/jfr-container-action/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
     - name: Move cache
       if: steps.cache-jenkins.outputs.cache-hit == 'true'
-      run: ls -al /jenkins_new_plugins && cp -r /jenkins_new_plugins /usr/share/jenkins/ref/plugins
+      run: ls -al /jenkins_new_plugins && cp -r /jenkins_new_plugins/* /usr/share/jenkins/ref/plugins
       shell: bash
     - name: Run Jenkins pipeline in the predefined container
       run: ${GITHUB_ACTION_PATH}/setup.sh ${{inputs.command}} ${{inputs.jenkinsfile}} ${{inputs.jcasc}}


### PR DESCRIPTION
1. Invalid cache for runtime type actions because the way of adding cache is not helpful at all. What's more, runtime type actions will not be supported in the future. The introduction of them will also be removed later.
2. Fix the path problem in jfr-container-action. We can see the difference of `cp -r /jenkins_new_plugins /usr/share/jenkins/ref/plugins` and `cp -r /jenkins_new_plugins/* /usr/share/jenkins/ref/plugins`. This bug makes the new installed plugins cannot be used in the `/usr/share/jenkins/ref/plugins`. I made this error because I did the test on `zsh` instead of `bash` and they'll have different results to this command.