### PR TITLE
Remove cache log

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,6 @@ jobs:
     steps:
       # Run in the on demand VM. GitHub Action helps to map the workspace into the following container.
       - uses: actions/checkout@v2
-      # Cannot uses the node in the following container.
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14      
       # Run in the Jenkins container which presents inside the on demand VM.
       - name: Jenkins pipeline with the static image
         id: jenkins_pipeline_image
@@ -72,8 +68,3 @@ jobs:
           jenkinsfile: Jenkinsfile
           pluginstxt: plugins_container.txt
           jcasc: jcasc.yml      
-      # The Jenkins container ends with the Jenkins Action.
-      # Run the following action in the on demand VM.
-      - name: Test System version
-        run: grep -oP 'VERSION=.* \K\w* \w*' /etc/os-release
-        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         name: Cache Jenkins
         with:
           path: /jenkins_new_plugins
-          key: ${{ runner.os }}-plugins-${{ hashFiles(plugins.txt) }}      
+          key: ${{ runner.os }}-plugins-${{ hashFiles('plugins.txt') }}      
       - name: Jenkins pipeline in the container
         id: jenkins_pipeline_container
         uses:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Upload pipeline Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: pipeline-log
+          name: jenkins-container-pipeline-log
           path: /jenkinsHome/jobs/job/builds
   jenkins-static-image-pipeline:
     runs-on: ubuntu-latest
@@ -68,3 +68,8 @@ jobs:
           jenkinsfile: Jenkinsfile
           pluginstxt: plugins_container.txt
           jcasc: jcasc.yml      
+      - name: Upload pipeline Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: jenkins-static-image-pipeline-log
+          path: jenkinsHome/jobs/job/builds          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       - uses: actions/checkout@v2
       # Cache new plugins in /jenkins_new_plugins by hash(plugins.txt)
       - uses: actions/cache@v3
-        id: cache-jenkins
-        name: Cache Jenkins
+        id: cache-jenkins-plugins
+        name: Cache Jenkins plugins
         with:
           path: /jenkins_new_plugins
           key: ${{ runner.os }}-plugins-${{ hashFiles('plugins.txt') }}      
@@ -45,7 +45,7 @@ jobs:
           jenkinsfile: Jenkinsfile
           pluginstxt: plugins_container.txt
           jcasc: jcasc.yml
-          isPluginCacheHit: steps.cache-jenkins.outputs.cache-hit
+          isPluginCacheHit: ${{steps.cache-jenkins-plugins.outputs.cache-hit}}
       # Upload pipeline log in /jenkinsHome/jobs/job/builds
       - name: Upload pipeline Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     name: jenkins-prebuilt-container-test
     container:
-      image: jenkins/jenkinsfile-runner
+      image: ghcr.io/cr1t-gym/jenkinsfile-runner-image-release-test:master
     steps:
       - uses: actions/checkout@v2
       # Cache new plugins in /jenkins_new_plugins by hash(plugins.txt)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
       image: jenkins/jenkinsfile-runner
     steps:
       - uses: actions/checkout@v2
+      # Cache new plugins in /jenkins_new_plugins by hash(plugins.txt)
+      - uses: actions/cache@v3
+        id: cache-jenkins
+        name: Cache Jenkins
+        with:
+          path: /jenkins_new_plugins
+          key: ${{ runner.os }}-plugins-${{ hashFiles(plugins.txt) }}      
       - name: Jenkins pipeline in the container
         id: jenkins_pipeline_container
         uses:
@@ -38,7 +45,13 @@ jobs:
           jenkinsfile: Jenkinsfile
           pluginstxt: plugins_container.txt
           jcasc: jcasc.yml
-          uploadLog: true
+          isPluginCacheHit: steps.cache-jenkins.outputs.cache-hit
+      # Upload pipeline log in /jenkinsHome/jobs/job/builds
+      - name: Upload pipeline Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: pipeline-log
+          path: /jenkinsHome/jobs/job/builds
   jenkins-static-image-pipeline:
     runs-on: ubuntu-latest
     name: jenkins-static-image-pipeline-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: jenkins-static-image-pipeline-log
-          path: jenkinsHome/jobs/job/builds          
+          path: jenkinsHome/jobs/job/builds
+         

--- a/jfr-container-action/action.yml
+++ b/jfr-container-action/action.yml
@@ -24,14 +24,14 @@ runs:
   using: "composite"
   steps:
     - name: Set up Jenkins war package
-      run: jar -cvf /app/jenkins/jenkins.war /app/jenkins/* && mkdir -p /jenkins_new_plugins && mkdir -p /jenkinsHome
+      run: jar -cvf /app/jenkins/jenkins.war /app/jenkins/* && mkdir -p /jenkins_new_plugins && mkdir -p /jenkinsHome && echo ${{inputs.isPluginCacheHit}}
       shell: bash
     - name: Download plugins
-      if: inputs.isPluginCacheHit != 'true'
+      if: ${{inputs.isPluginCacheHit != 'true'}}
       run: ${GITHUB_ACTION_PATH}/download.sh ${{inputs.pluginstxt}}
       shell: bash
     - name: Move cache
-      if: inputs.isPluginCacheHit == 'true'
+      if: ${{inputs.isPluginCacheHit == 'true'}}
       run: ls -al /jenkins_new_plugins && cp -r /jenkins_new_plugins/* /usr/share/jenkins/ref/plugins
       shell: bash
     - name: Run Jenkins pipeline in the predefined container

--- a/jfr-container-action/action.yml
+++ b/jfr-container-action/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Jenkins war package
-      run: jar -cvf /app/jenkins/jenkins.war /app/jenkins/* && mkdir -p /jenkins_new_plugins && mkdir -p /jenkinsHome && echo ${{inputs.isPluginCacheHit}}
+      run: jar -cvf /app/jenkins/jenkins.war /app/jenkins/* && mkdir -p /jenkins_new_plugins && mkdir -p /jenkinsHome
       shell: bash
     - name: Download plugins
       if: ${{inputs.isPluginCacheHit != 'true'}}

--- a/jfr-container-action/action.yml
+++ b/jfr-container-action/action.yml
@@ -16,37 +16,24 @@ inputs:
   jcasc:
     description: Jenkins CasC file
     required: false
-  uploadLog:
-    description: whether to upload the pipeline result
-    type: boolean
+  isPluginCacheHit:
+    description: The plugin cache hit status. If you use actions/cache outside, you can simply give its output as input here.
     required: false
-    default: false    
+    default: false 
 runs:
   using: "composite"
   steps:
     - name: Set up Jenkins war package
       run: jar -cvf /app/jenkins/jenkins.war /app/jenkins/* && mkdir -p /jenkins_new_plugins && mkdir -p /jenkinsHome
       shell: bash
-    - uses: actions/cache@v3
-      id: cache-jenkins
-      name: Cache Jenkins
-      with:
-        path: /jenkins_new_plugins
-        key: ${{ runner.os }}-plugins-${{ hashFiles(inputs.pluginstxt) }}
     - name: Download plugins
-      if: steps.cache-jenkins.outputs.cache-hit != 'true'
+      if: inputs.isPluginCacheHit != 'true'
       run: ${GITHUB_ACTION_PATH}/download.sh ${{inputs.pluginstxt}}
       shell: bash
     - name: Move cache
-      if: steps.cache-jenkins.outputs.cache-hit == 'true'
+      if: inputs.isPluginCacheHit == 'true'
       run: ls -al /jenkins_new_plugins && cp -r /jenkins_new_plugins/* /usr/share/jenkins/ref/plugins
       shell: bash
     - name: Run Jenkins pipeline in the predefined container
       run: ${GITHUB_ACTION_PATH}/setup.sh ${{inputs.command}} ${{inputs.jenkinsfile}} ${{inputs.jcasc}}
       shell: bash
-    - name: Upload pipeline Artifacts
-      if: ${{inputs.uploadLog == 'true'}}
-      uses: actions/upload-artifact@v3
-      with:
-        name: pipeline-log
-        path: /jenkinsHome/jobs/job/builds

--- a/jfr-container-action/setup.sh
+++ b/jfr-container-action/setup.sh
@@ -15,3 +15,4 @@ fi
 
 echo "Running Jenkins pipeline."
 /app/bin/jenkinsfile-runner-launcher "$1" -w /app/jenkins -p /usr/share/jenkins/ref/plugins -f "$2" --runHome /jenkinsHome
+echo "The pipeline log is available at /jenkinsHome/jobs/job/builds!"

--- a/jfr-static-image-action/Dockerfile
+++ b/jfr-static-image-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkinsfile-runner
+FROM ghcr.io/cr1t-gym/jenkinsfile-runner-image-release-test:master
 
 COPY entrypoint.sh /entrypoint.sh
 RUN cd /app/jenkins && jar -cvf jenkins.war *

--- a/jfr-static-image-action/action.yml
+++ b/jfr-static-image-action/action.yml
@@ -18,7 +18,8 @@ inputs:
     required: false    
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'ghcr.io/cr1t-gym/jenkinsfile-runner-image-release-test:master'
+  entrypoint: entrypoint.sh
   args:
     - ${{inputs.command}}
     - ${{inputs.jenkinsfile}}

--- a/jfr-static-image-action/action.yml
+++ b/jfr-static-image-action/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: 'docker'
   image: 'ghcr.io/cr1t-gym/jenkinsfile-runner-image-release-test:master'
-  entrypoint: ${GITHUB_WORKSPACE}/entrypoint.sh
+  entrypoint: /github/workspace/entrypoint.sh
   args:
     - ${{inputs.command}}
     - ${{inputs.jenkinsfile}}

--- a/jfr-static-image-action/action.yml
+++ b/jfr-static-image-action/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: 'docker'
   image: 'ghcr.io/cr1t-gym/jenkinsfile-runner-image-release-test:master'
-  entrypoint: entrypoint.sh
+  entrypoint: ${GITHUB_WORKSPACE}/entrypoint.sh
   args:
     - ${{inputs.command}}
     - ${{inputs.jenkinsfile}}

--- a/jfr-static-image-action/action.yml
+++ b/jfr-static-image-action/action.yml
@@ -18,8 +18,7 @@ inputs:
     required: false    
 runs:
   using: 'docker'
-  image: 'ghcr.io/cr1t-gym/jenkinsfile-runner-image-release-test:master'
-  entrypoint: /github/workspace/entrypoint.sh
+  image: 'Dockerfile'
   args:
     - ${{inputs.command}}
     - ${{inputs.jenkinsfile}}

--- a/jfr-static-image-action/entrypoint.sh
+++ b/jfr-static-image-action/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-cd /app/jenkins && jar -cvf jenkins.war * && cd $GITHUB_WORKSPACE
 echo "Download plugins."
 java -jar /app/bin/jenkins-plugin-manager.jar --war /app/jenkins/jenkins.war --plugin-file "$3" --plugin-download-directory=/usr/share/jenkins/ref/plugins
 

--- a/jfr-static-image-action/entrypoint.sh
+++ b/jfr-static-image-action/entrypoint.sh
@@ -11,4 +11,6 @@ then
 fi
 
 echo "Running Jenkins pipeline."
-/app/bin/jenkinsfile-runner-launcher "$1" -w /app/jenkins -p /usr/share/jenkins/ref/plugins -f "$2"
+mkdir -p jenkinsHome
+/app/bin/jenkinsfile-runner-launcher "$1" -w /app/jenkins -p /usr/share/jenkins/ref/plugins -f "$2" --runHome jenkinsHome
+echo "The pipeline log is available at jenkinsHome/jobs/job/builds!"

--- a/jfr-static-image-action/entrypoint.sh
+++ b/jfr-static-image-action/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+cd /app/jenkins && jar -cvf jenkins.war * && cd $GITHUB_WORKSPACE
 echo "Download plugins."
 java -jar /app/bin/jenkins-plugin-manager.jar --war /app/jenkins/jenkins.war --plugin-file "$3" --plugin-download-directory=/usr/share/jenkins/ref/plugins
 


### PR DESCRIPTION
* Remove the plugins cache in `jfr-container-action`. Now the users can choose whether or not to cache new installed plugins outside. If users want to use `actions/cache` in the workflow, they can give the cache hit status as input in `isPluginCacheHit`. The plugins cache will be invalid by default. Why do we need this change? Because we want to delegate the resposibility of calling cache to the users. The users only need to cache `/jenkins_new_plugins` by `hashFiles('plugins.txt')`.
* Remove log uploading service inside the actions. Why do we need this change? Because we want to delegate the resposibility of calling uploading service to the users. Now the users can access the logs in `/jenkinsHome/jobs/job/builds` if they use `jfr-container-action` or access the logs in `jenkinsHome/jobs/job/builds` if they use `jfr-static-image-action`.
* Support reflecting the environmental variables in `jfr-static-image-action`. Nothing needs to be changed.
* Turn to use `ghcr.io/cr1t-gym/jenkinsfile-runner-image-release-test:master` as base image in these actions as we discussed in the meeting.

I also added the examples of using plugins cache and log uploading service in the workflow definition.